### PR TITLE
Configure website for LLM/AI crawler access

### DIFF
--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "CustomsLens",
+  "name_for_model": "customslens",
+  "description_for_human": "CustomsLens - Customs clearance and international trade services",
+  "description_for_model": "Website for CustomsLens, providing information about customs clearance, international trade services, and logistics solutions.",
+  "auth": {
+    "type": "none"
+  },
+  "api": {
+    "type": "website",
+    "url": "https://customslens.nl"
+  },
+  "logo_url": "https://customslens.nl/logo.png",
+  "contact_email": "info@customslens.nl",
+  "legal_info_url": "https://customslens.nl/privacy"
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,18 @@
+# Allow all crawlers by default
 User-agent: *
+Allow: /
+
+# Explicitly allow AI/LLM crawlers
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: CCBot
 Allow: /
 
 Sitemap: https://customslens.nl/sitemap.xml

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,27 @@
+{
+  "functions": {
+    "app/**": {
+      "maxDuration": 30
+    }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "index, follow"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Updated robots.txt to explicitly allow AI crawlers (ClaudeBot, GPTBot, ChatGPT-User, CCBot)
- Added .well-known/ai-plugin.json for ChatGPT plugin support  
- Created vercel.json with X-Robots-Tag headers and CORS configuration
- Set function timeout to 30 seconds for API routes

## Changes
This PR configures the website to be properly accessible by LLM and AI crawlers:

### robots.txt
- Explicitly allows major AI crawlers including Claude, GPT, and Common Crawl bots

### .well-known/ai-plugin.json
- Provides metadata for AI systems to better understand the website
- Enables potential ChatGPT plugin functionality

### vercel.json
- Sets `X-Robots-Tag: index, follow` headers for all pages
- Configures CORS for API endpoints
- Sets appropriate function timeouts

🤖 Generated with [Claude Code](https://claude.ai/code)